### PR TITLE
Add OpenSergoClientManager to support client reuse

### DIFF
--- a/src/main/java/io/opensergo/OpenSergoClient.java
+++ b/src/main/java/io/opensergo/OpenSergoClient.java
@@ -48,12 +48,39 @@ public class OpenSergoClient implements AutoCloseable {
 
     private AtomicInteger reqId;
 
-    public OpenSergoClient(String host, int port) {
-        // TODO: support customized config for the OpenSergoClient.
+    public static class Builder {
+
+        private String host;
+        private int port;
+        private OpenSergoConfig openSergoConfig;
+
+        public OpenSergoClient.Builder endpoint(String host, int port) {
+            this.host = host;
+            this.port = port;
+            return this;
+        }
+
+        public OpenSergoClient.Builder openSergoConfig(OpenSergoConfig openSergoConfig) {
+            this.openSergoConfig = openSergoConfig;
+            return this;
+        }
+
+        public OpenSergoClient build() {
+            if (this.openSergoConfig == null) {
+                this.openSergoConfig = new OpenSergoConfig();
+            }
+
+            return new OpenSergoClient(this.host, this.port, this.openSergoConfig);
+        }
+
+    }
+
+    private OpenSergoClient(String host, int port, OpenSergoConfig config) {
+        // TODO: add customized config business for the OpenSergoClient.
         // TODO: support TLS
         this.channel = ManagedChannelBuilder.forAddress(host, port)
-            .usePlaintext()
-            .build();
+                .usePlaintext()
+                .build();
         this.transportGrpcStub = OpenSergoUniversalTransportServiceGrpc.newStub(channel);
         this.configCache = new SubscribedConfigCache();
         this.subscribeRegistry = new SubscribeRegistry();

--- a/src/main/java/io/opensergo/OpenSergoClientManager.java
+++ b/src/main/java/io/opensergo/OpenSergoClientManager.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022, OpenSergo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.opensergo;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * .
+ *
+ * @author Jiangnan Jia
+ **/
+public class OpenSergoClientManager {
+
+    private static volatile OpenSergoClientManager instance;
+
+    /**
+     * Cached all the shared OpenSergoClients.
+     */
+    private ConcurrentHashMap<String, OpenSergoClient> sharedOpenSergoClientCache = new ConcurrentHashMap<>();
+
+
+    private OpenSergoClientManager() {
+
+    }
+
+    /**
+     * get OpenSergoClientManager by DCL (Double Check Lock)
+     * @return
+     */
+    public static OpenSergoClientManager get() {
+        if (instance == null) {
+            synchronized (OpenSergoClientManager.class) {
+                if (instance == null) {
+                    return new OpenSergoClientManager();
+                }
+            }
+        }
+        return instance;
+    }
+
+    private String buildSharedCacheKey(String host, int port) {
+        return host + ":" + port;
+    }
+
+    /**
+     * get the instance from sharedOpenSergoClientCache，
+     * if there is no one， will create a new instance and return it.
+     *
+     * @param host endpoint of the OpenSergo Control Plane
+     * @param port port of the OpenSergo Control Plane
+     * @return OpenSergoClient
+     */
+    public OpenSergoClient getOrCreateClient(String host, int port) {
+        return this.getOrCreateClient(host, port, new OpenSergoConfig());
+    }
+
+    /**
+     * get the instance from sharedOpenSergoClientCache with config.
+     * If instance can be found by host and port, the one will be returned, whether the config is matched or not.
+     *
+     * @param host endpoint of the OpenSergo Control Plane
+     * @param port port of the OpenSergo Control Plane
+     * @param config OpenSergoConfig
+     * @return OpenSergoClient
+     */
+    public OpenSergoClient getOrCreateClient(String host, int port, OpenSergoConfig config) {
+        String sharedOpenSergoClientKey = buildSharedCacheKey(host, port);
+        OpenSergoClient openSergoClient = sharedOpenSergoClientCache.get(sharedOpenSergoClientKey);
+
+        if (openSergoClient != null) {
+            return openSergoClient;
+        }
+
+        config = config == null ? new OpenSergoConfig() : config;
+        openSergoClient = new OpenSergoClient.Builder().endpoint(host, port).openSergoConfig(config).build();
+        sharedOpenSergoClientCache.putIfAbsent(sharedOpenSergoClientKey, openSergoClient);
+        return sharedOpenSergoClientCache.get(sharedOpenSergoClientKey);
+    }
+
+}

--- a/src/main/java/io/opensergo/OpenSergoConfig.java
+++ b/src/main/java/io/opensergo/OpenSergoConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022, OpenSergo Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.opensergo;
+
+/**
+ * .
+ *
+ * @author Jiangnan Jia
+ **/
+public class OpenSergoConfig {
+
+}


### PR DESCRIPTION
Signed-off-by: Jiangnan Jia <jnan0806@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: 
   for English: https://opensergo.io/docs/community/contribution-guidance
   for Chinese: https://opensergo.io/zh-cn/docs/community/contribution-guidance
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
support client reuse

### Does this pull request fix one issue?

<!--If that, add "Fixes #xxxx" below in the next line. For example, Fixes #1. Otherwise, add "NONE" -->
Fixes #8 

### Describe how you did it
- Add `OpenSergoClientManager` to manage the reuse OpenSergoClient
- Add `Builder` in OpenSergoClient for creating instance
- Add `OpenSergoConfig` to support customized config

### Describe how to verify it
- for shared OpenSergoClient
``` java
OpenSergoClient openSergoClient = OpenSergoClientManager.get().getOrCreateClient("127.0.0.1", 10246, new OpenSergoConfig());
```
- for prototype OpenSergoClient
``` java 
OpenSergoClient openSergoClient = new OpenSergoClient.Builder().endpoint("127.0.0.1", 
10246).openSergoConfig(new OpenSergoConfig()).build();
```

### Special notes for reviews